### PR TITLE
Add support in suffix / prefix per processed file

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -41,6 +41,9 @@ var createSpringMessagesPreprocessor = function(args, config, logger, helper) {
         };
 
     return function(content, file, done) {
+        var prefix = typeof options.prefix === 'object' ? options.prefix[file.originalPath] : options.prefix,
+            suffix = typeof options.suffix === 'object' ? options.suffix[file.originalPath] : options.suffix;
+        
         log.debug("Processing %s", file.originalPath);
         file.path = transformPath(file.originalPath);
 
@@ -48,7 +51,7 @@ var createSpringMessagesPreprocessor = function(args, config, logger, helper) {
 
         var tree = processor.process(lines);
 
-        done(null, options.prefix + CONSTANT_PREFIX + Node.render(tree) + CONSTANT_SUFFIX + options.suffix);
+        done(null, prefix + CONSTANT_PREFIX + Node.render(tree) + CONSTANT_SUFFIX + suffix);
     };
 
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -25,6 +25,27 @@ CONSTANT_SUFFIX += "};\n";
 
 var Node = require('./Node');
 var processor = require('./processor');
+var minimatch = require('minimatch');
+
+var findFirstMatchingConfig = function(configsMap, fileName) {
+    if(typeof configsMap === 'string') { //no map - single config to prepend/append to every processed file
+        return configsMap;
+    }
+
+    //test if the current processed file matches a glob pattern in the additions map keys.
+    //If match is found - use the value as the chosen config. The first match found - wins
+    var result = "";
+    
+    //TODO: this has side effects, prefer Array.prototype.find for newer node versions
+    Object.keys(configsMap).some(function(pattern) {
+        if(minimatch(fileName, pattern)) {
+            result = configsMap[pattern];
+            return true;
+        }
+    });
+
+    return result;
+};
 
 var createSpringMessagesPreprocessor = function(args, config, logger, helper) {
     config = config || {};
@@ -41,11 +62,12 @@ var createSpringMessagesPreprocessor = function(args, config, logger, helper) {
         };
 
     return function(content, file, done) {
-        var prefix = typeof options.prefix === 'object' ? options.prefix[file.originalPath] : options.prefix,
-            suffix = typeof options.suffix === 'object' ? options.suffix[file.originalPath] : options.suffix;
+        var fileName = file.originalPath,
+            prefix = findFirstMatchingConfig(options.prefix, fileName),
+            suffix = findFirstMatchingConfig(options.suffix, fileName);
         
-        log.debug("Processing %s", file.originalPath);
-        file.path = transformPath(file.originalPath);
+        log.debug("Processing %s", fileName);
+        file.path = transformPath(fileName);
 
         var lines = content.split("\n");
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/MadaraUchiha/karma-spring-messages-preprocessor/issues"
   },
   "homepage": "https://github.com/MadaraUchiha/karma-spring-messages-preprocessor#readme",
+  "dependencies": {
+    "minimatch": "^3.0.0"
+  },
   "devDependencies": {
     "mocha": "^2.4.5",
     "should": "^8.2.1"


### PR DESCRIPTION
Currently suffix / prefix options are passed as strings and are being applied to every processed file. This change allows passing an these options as an object, where the key is the file to which this option applies to and the value is the prefix/suffix to add. e.g:

``` javascript
suffix: {
  '../path/to/file1': 'obj1 = getMessages();',
  '../path/to/file2': 'obj2 = getMessages();'
}
```
